### PR TITLE
Reserve space for animation samplers in serialization

### DIFF
--- a/include/tiny_gltf.h
+++ b/include/tiny_gltf.h
@@ -6455,6 +6455,7 @@ static void SerializeGltfAnimation(Animation &animation, json &o) {
 
   {
     json samplers;
+    JsonReserveArray(samplers, animation.samplers.size());
     for (unsigned int i = 0; i < animation.samplers.size(); ++i) {
       json sampler;
       AnimationSampler gltfSampler = animation.samplers[i];


### PR DESCRIPTION
Fixes a seg fault. Didn't find a similar fix in the mainline